### PR TITLE
Fixed invalid import in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ import { fadeIn } from 'react-animations'
 or you can import a specific animation directly
 
 ```js
-import fadeIn from 'react-animations/lib/fade-in'
+import fadeIn from 'react-animations/lib/fadeIn'
 ```
 
 


### PR DESCRIPTION
In the latest version of react-animations the fadeIn component isn't located at `react-animations/lib/fade-in` but at `react-animations/lib/fadeIn`

This is probably the best pull requests I've ever done 